### PR TITLE
Reproduction for `models.Post.findOne` returning nothing when there is no `status` filter

### DIFF
--- a/test/e2e-api/admin/posts.test.js
+++ b/test/e2e-api/admin/posts.test.js
@@ -575,8 +575,7 @@ describe('Posts API', function () {
             .expect(200);
 
         model = await models.Post.findOne({
-            id: id,
-            status: 'published'
+            id: id
         }, testUtils.context.internal);
         should(model.get('newsletter_id')).eql(newsletterId);
 
@@ -594,8 +593,7 @@ describe('Posts API', function () {
             .expect(200);
 
         model = await models.Post.findOne({
-            id: id,
-            status: 'draft'
+            id: id
         }, testUtils.context.internal);
         should(model.get('newsletter_id')).eql(newsletterId);
 
@@ -613,8 +611,7 @@ describe('Posts API', function () {
             .expect(200);
 
         model = await models.Post.findOne({
-            id: id,
-            status: 'published'
+            id: id
         }, testUtils.context.internal);
         should(model.get('newsletter_id')).eql(newsletterId);
     });


### PR DESCRIPTION
- It seems like `await models.Post.findOne({id}, testUtils.context.internal)` should work fine, but it does return null while adding a filter on the status like `await models.Post.findOne({id, status: 'published'}, testUtils.context.internal);` is returning the correct post.

The PR with the code that works is there: https://github.com/TryGhost/Ghost/pull/14485